### PR TITLE
Fix range on xsections histogram.

### DIFF
--- a/src/nuwro.cc
+++ b/src/nuwro.cc
@@ -693,7 +693,7 @@ void NuWro::real_events(params& p)
 	TTree *tf = new TTree ("treeout", "Tree of events");
 	tf->Branch ("e", "event", &e);
 	delete e;
-	TH1 * xsections= new TH1D("xsections","xsections",8,0,7);
+	TH1 * xsections= new TH1D("xsections","xsections",_procesy.size(),0,_procesy.size());
 	for(int i=0;i<_procesy.size();i++)
 	{
 		xsections->SetBinContent(i+1,_procesy.avg(i));


### PR DESCRIPTION
Minor bug fix. The xsections histogram in the nuwro output file can be incorrectly filled if the number of channels simulated is more than 8. This causes MEC CC and MEC NC to be missing from the histogram.

Setting the binning based on the size of the process chooser (_procesy) fixes this problem (and will also behave correctly in future if additional channels are added).
